### PR TITLE
#10 team detection

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/TeamDetection.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/TeamDetection.java
@@ -2,16 +2,50 @@ package org.firstinspires.ftc.teamcode.util;
 
 import com.qualcomm.robotcore.hardware.DigitalChannel;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 
 public class TeamDetection {
-    public boolean redTeam = false;
-    public boolean blueTeam = false;
+    public boolean redTeam;
+    public boolean blueTeam;
 
-
-
+    /**
+     * Returns what team you are on from the switch.
+     * requires a switch configured as "blueSwitch"
+     * Blue is true, and Red is false
+     *
+     * @param hardwareMap OpMode hardwareMap
+     *
+     */
     public TeamDetection(HardwareMap hardwareMap){
+
+        //find value of switch
         DigitalChannel blueSwitch = hardwareMap.get(DigitalChannel.class, "blueSwitch");
         blueSwitch.setMode(DigitalChannel.Mode.INPUT);
-         = blueSwitch.getState();
+
+        //set two values according to the switch
+        blueTeam = blueSwitch.getState();
+        redTeam = !blueTeam;
+    }
+
+    /**
+     * Broadcasts variables:
+     * blueTeam (true/false)
+     * redTeam (true/false)
+     *
+     * @param telemetry OpMode telemetry
+     */
+    public void showTeam(Telemetry telemetry) {
+
+        //let the driver know what it detected
+        if(blueTeam) {
+            telemetry.addData("Team:Blue", true);
+            telemetry.addData("Team:Red", false);
+        }
+
+        if(redTeam) {
+            telemetry.addData("Team:Blue", false);
+            telemetry.addData("Team:Red", true);
+        }
     }
 }
+//boom! now we know what team we're on!

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/TeamDetection.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/TeamDetection.java
@@ -1,0 +1,17 @@
+package org.firstinspires.ftc.teamcode.util;
+
+import com.qualcomm.robotcore.hardware.DigitalChannel;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+public class TeamDetection {
+    public boolean redTeam = false;
+    public boolean blueTeam = false;
+
+
+
+    public TeamDetection(HardwareMap hardwareMap){
+        DigitalChannel blueSwitch = hardwareMap.get(DigitalChannel.class, "blueSwitch");
+        blueSwitch.setMode(DigitalChannel.Mode.INPUT);
+         = blueSwitch.getState();
+    }
+}


### PR DESCRIPTION
Before issuing a pull request, please see the contributing page.

⚠WARNING⚠
Has not been tested

Returns what team you are on from the switch.
requires a switch configured as `blueSwitch`
For blue to be true, the switch must be "1"
for red to be true, the switch must be "0"

